### PR TITLE
Add per-route middleware

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -7,9 +7,10 @@ import (
 
 // Definition defines a new route for the application.
 type Definition struct {
-	Methods []string
-	Handler http.Handler
-	URI     string
+	Methods    []string
+	Handler    http.Handler
+	URI        string
+	middleware []Middleware
 }
 
 // Redirect takes a `from` URI and a `to` URI and creates a new
@@ -52,6 +53,11 @@ func Delete(uri string, handler interface{}) Definition {
 // Options creates a OPTIONS route using the given URI.
 func Options(uri string, handler interface{}) Definition {
 	return createDefinition(uri, handler, http.MethodOptions)
+}
+
+func (d Definition) Middleware(middleware ...Middleware) Definition {
+	d.middleware = middleware
+	return d
 }
 
 func createDefinition(uri string, handler interface{}, methods ...string) Definition {

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -91,3 +91,17 @@ type TestStringer int
 func (TestStringer) String() string {
 	return "Just Testing"
 }
+
+func MiddlewareTester(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("A TEST "))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func MiddlewareTesterTwo(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("THIS IS "))
+		next.ServeHTTP(w, r)
+	})
+}

--- a/route/transform.go
+++ b/route/transform.go
@@ -1,6 +1,8 @@
 package route
 
-import "github.com/gorilla/mux"
+import (
+	"github.com/gorilla/mux"
+)
 
 func tidyPath(path string) string {
 	if path[0] != '/' {
@@ -17,19 +19,36 @@ func tidyPath(path string) string {
 func TransformGorilla(r *mux.Router, group *Group) *mux.Router {
 	var s *mux.Router
 
+	// If the Collection has a prefix applied to it, then create
+	// all the routes within it using the prefix.
 	if group.prefix != "" {
 		s = r.PathPrefix(group.prefix).Subrouter()
 	} else {
 		s = r.NewRoute().Subrouter()
 	}
 
+	// Gorilla allows middleware to be added to an entire subrouter,
+	// so any middleware that are defined against the collection
+	// are added to the subrouter here.
 	for _, mw := range group.middleware {
 		s.Use(mux.MiddlewareFunc(mw))
 	}
 
+	// Iterate through each route in the collection and add it
+	// to the gorilla mux instance.
 	for _, route := range group.routes {
+		// First, ensure the path is well formed. This allows
+		// users to omit the leading slash on a route.
 		path := tidyPath(route.URI)
-		s.Methods(route.Methods...).Path(path).Handler(route.Handler)
+
+		// Then, iterate through any middleware that are defined
+		// on the individual route and use each to wrap the
+		// handler. This enables per-route middleware.
+		handler := route.Handler
+		for _, mw := range route.middleware {
+			handler = mw(handler)
+		}
+		s.Methods(route.Methods...).Path(path).Handler(handler)
 	}
 
 	return s


### PR DESCRIPTION
Routes can now have middleware assigned to them individually, rather than as part of the route group.

To do so, chain `.Middleware(...middleware)` to the definition in the collection.